### PR TITLE
Whanou/tree view mobile version

### DIFF
--- a/packages/core/src/components/IconButton.tsx
+++ b/packages/core/src/components/IconButton.tsx
@@ -26,7 +26,7 @@ export const IconButton = ({
         className,
         sizeClasses[size],
         "inline-flex aspect-square shrink-0 items-center justify-center",
-        "rounded border border-gray-200 bg-transparent dark:border-gray-800",
+        "rounded border border-gray-200 bg-transparent dark:border-gray-600",
         "text-gray-500 dark:text-gray-400",
         "hover:bg-gray-200 dark:hover:bg-gray-800",
         "outline-none outline-offset-0 focus-visible:outline-1 focus-visible:outline-blue-600 dark:focus-visible:outline-blue-300",

--- a/packages/core/src/components/Input.tsx
+++ b/packages/core/src/components/Input.tsx
@@ -8,12 +8,13 @@ import {
 import cn from "classnames";
 import { X } from "lucide-react";
 
-interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   onValueChange?: (value: string) => void;
   startIcon?: ReactNode;
   onClear?: () => void;
   clearable?: boolean;
   ref?: RefObject<HTMLInputElement | null>;
+  inputClassName?: string;
 }
 
 const iconBaseClassName =
@@ -27,6 +28,7 @@ export const Input = ({
   onClear,
   clearable = true,
   ref,
+  inputClassName,
   ...props
 }: InputProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -48,18 +50,23 @@ export const Input = ({
   };
 
   return (
-    <div className="relative">
+    <div
+      className={cn(
+        "relative flex w-full items-center justify-center",
+        className,
+      )}
+    >
       <input
         {...props}
         ref={ref || inputRef}
         onChange={handleChange}
         className={cn(
-          className,
-          "flex h-8 items-center truncate",
-          "px-2",
+          inputClassName,
+          "flex h-7 items-center truncate",
+          "w-full px-2",
           !!startIcon && "pl-8",
           !!onClear && "pr-8",
-          "rounded border border-gray-200 bg-transparent dark:border-gray-800",
+          "rounded border border-gray-200 bg-transparent dark:border-gray-600",
           "text-gray-700 placeholder:text-gray-400 dark:text-gray-200 dark:placeholder:text-gray-600",
           "hover:border-gray-300 dark:hover:border-gray-700",
           "outline-none outline-offset-0 focus-visible:outline-1 focus-visible:outline-blue-600 dark:focus-visible:outline-blue-300",

--- a/packages/core/src/components/SpanCardBadges.tsx
+++ b/packages/core/src/components/SpanCardBadges.tsx
@@ -7,19 +7,15 @@ import {
 } from "../utils/ui";
 import { Badge } from "./Badge";
 
-interface SpanCardContentProps {
+interface SpanCardBagdesProps {
   data: SpanCardType;
 }
 
-export const SpanCardContent = ({ data }: SpanCardContentProps) => {
+export const SpanCardBadges = ({ data }: SpanCardBagdesProps) => {
   const Icon = getSpanCategoryIcon(data.type);
 
   return (
     <div className="flex flex-wrap items-center justify-start gap-1">
-      <h3 className="mr-3 max-w-32 truncate text-sm leading-5 text-gray-900 dark:text-gray-200">
-        {data.title}
-      </h3>
-
       <Badge
         iconStart={<Icon className="size-2.5" />}
         theme={getSpanCategoryTheme(data.type)}

--- a/packages/core/src/components/SpanCardConnectors.tsx
+++ b/packages/core/src/components/SpanCardConnectors.tsx
@@ -1,18 +1,27 @@
 interface SpanCardHorizontalConnectorProps {
   level: number;
-  horizontalLineWidth: number;
+  hasCollapseButton: boolean;
+  stepLength: number;
 }
 
 export const SpanCardHorizontalConnector = ({
   level,
-  horizontalLineWidth,
+  hasCollapseButton,
+  stepLength,
 }: SpanCardHorizontalConnectorProps) => {
   if (level === 0) return null;
 
+  const horizontalLineWidth = hasCollapseButton
+    ? stepLength * 0.5
+    : stepLength * 0.5;
+
   return (
     <div
-      className="absolute -left-[15px] top-2.5 h-0.5 bg-gray-100 dark:bg-gray-800"
-      style={{ width: `${horizontalLineWidth}px` }}
+      className="absolute top-1.5 h-0.5 bg-gray-100 dark:bg-gray-800"
+      style={{
+        width: `${horizontalLineWidth}px`,
+        left: `-${horizontalLineWidth}px`,
+      }}
     />
   );
 };

--- a/packages/core/src/components/SpanCardConnectors.tsx
+++ b/packages/core/src/components/SpanCardConnectors.tsx
@@ -3,7 +3,7 @@ interface SpanCardHorizontalConnectorProps {
   horizontalLineWidth: number;
 }
 
-export const SpanCardHorizaontalConnector = ({
+export const SpanCardHorizontalConnector = ({
   level,
   horizontalLineWidth,
 }: SpanCardHorizontalConnectorProps) => {

--- a/packages/core/src/components/SpanCardContent.tsx
+++ b/packages/core/src/components/SpanCardContent.tsx
@@ -15,32 +15,26 @@ export const SpanCardContent = ({ data }: SpanCardContentProps) => {
   const Icon = getSpanCategoryIcon(data.type);
 
   return (
-    <div className="flex items-center">
+    <div className="flex flex-wrap items-center justify-start gap-1">
       <h3 className="mr-3 max-w-32 truncate text-sm leading-5 text-gray-900 dark:text-gray-200">
         {data.title}
       </h3>
 
-      <div className="flex items-center justify-start space-x-1">
-        <Badge
-          iconStart={<Icon className="size-2.5" />}
-          theme={getSpanCategoryTheme(data.type)}
-          size="xs"
-        >
-          {getSpanCategoryLabel(data.type)}
-        </Badge>
+      <Badge
+        iconStart={<Icon className="size-2.5" />}
+        theme={getSpanCategoryTheme(data.type)}
+        size="xs"
+      >
+        {getSpanCategoryLabel(data.type)}
+      </Badge>
 
-        <Badge
-          iconStart={<Coins className="size-2.5" />}
-          theme="gray"
-          size="xs"
-        >
-          {data.tokensCount}
-        </Badge>
+      <Badge iconStart={<Coins className="size-2.5" />} theme="gray" size="xs">
+        {data.tokensCount}
+      </Badge>
 
-        <Badge theme="gray" size="xs">
-          $ {data.cost}
-        </Badge>
-      </div>
+      <Badge theme="gray" size="xs">
+        $ {data.cost}
+      </Badge>
     </div>
   );
 };

--- a/packages/core/src/components/SpanCardSearchInput.tsx
+++ b/packages/core/src/components/SpanCardSearchInput.tsx
@@ -1,26 +1,12 @@
-import { useEffect, useState } from "react";
-import { Input } from "./Input";
+import { Input, type InputProps } from "./Input";
 import { Search } from "lucide-react";
 
-interface SpanCardSearchInputProps {
-  onSearch: (value: string) => void;
-}
-
-export const SpanCardSearchInput = ({ onSearch }: SpanCardSearchInputProps) => {
-  const [value, setValue] = useState("");
-
-  useEffect(() => {
-    onSearch(value);
-  }, [value, onSearch]);
-
+export const SpanCardSearchInput = ({ ...props }: InputProps) => {
   return (
     <Input
-      value={value}
-      onValueChange={setValue}
       startIcon={<Search className="size-4" />}
       placeholder="Filter..."
-      onClear={() => setValue("")}
-      clearable={!!value}
+      {...props}
     />
   );
 };

--- a/packages/core/src/components/SpanCardStatus.tsx
+++ b/packages/core/src/components/SpanCardStatus.tsx
@@ -31,16 +31,35 @@ export const SpanCardStatus = ({
 }: SpanCardStatusProps) => {
   const title = `Status: ${status}`;
 
-  if (variant === "dot") {
-    return (
-      <span
-        className={cn("block size-1.5 rounded-full", STATUS_COLORS_DOT[status])}
-        aria-label={title}
-        title={title}
-      />
-    );
-  }
+  return (
+    <div className="flex size-5 items-center justify-center">
+      {variant === "dot" ? (
+        <SpanCardStatusDot status={status} title={title} />
+      ) : (
+        <SpanCardStatusBadge status={status} title={title} />
+      )}
+    </div>
+  );
+};
 
+interface SpanCardStatusWithTitleProps extends SpanCardStatusProps {
+  title: string;
+}
+
+const SpanCardStatusDot = ({ status, title }: SpanCardStatusWithTitleProps) => {
+  return (
+    <span
+      className={cn("block size-1.5 rounded-full", STATUS_COLORS_DOT[status])}
+      aria-label={title}
+      title={title}
+    />
+  );
+};
+
+const SpanCardStatusBadge = ({
+  status,
+  title,
+}: SpanCardStatusWithTitleProps) => {
   return (
     <span
       className={cn(

--- a/packages/core/src/components/SpanCardTimeline.tsx
+++ b/packages/core/src/components/SpanCardTimeline.tsx
@@ -35,7 +35,7 @@ export const SpanCardTimeline = ({
   });
 
   return (
-    <span className="relative h-4 min-w-16 flex-1 rounded bg-gray-200 dark:bg-gray-900">
+    <span className="relative flex h-4 min-w-16 flex-1 rounded bg-gray-200 dark:bg-gray-900">
       <span className="pointer-events-none absolute inset-x-1 top-1/2 h-1.5 -translate-y-1/2">
         <span
           className={`absolute h-full rounded-sm ${timelineBgColors[theme]}`}

--- a/packages/core/src/components/SpanCardTimeline.tsx
+++ b/packages/core/src/components/SpanCardTimeline.tsx
@@ -1,12 +1,12 @@
-import { formatDuration } from "../services/calculate-duration";
+import { getTimelineData } from "../services/get-timeline-data";
+import type { SpanCardType } from "../types/span";
 import type { ColorVariant } from "../types/ui";
 
 interface SpanCardTimelineProps {
-  startTime: Date;
-  endTime: Date;
+  spanCard: SpanCardType;
+  theme: ColorVariant;
   minStart: number;
   maxEnd: number;
-  theme: ColorVariant;
 }
 
 const timelineBgColors: Record<ColorVariant, string> = {
@@ -23,34 +23,27 @@ const timelineBgColors: Record<ColorVariant, string> = {
 };
 
 export const SpanCardTimeline = ({
-  startTime,
-  endTime,
+  spanCard,
+  theme,
   minStart,
   maxEnd,
-  theme,
 }: SpanCardTimelineProps) => {
-  const startMs = +startTime;
-  const endMs = +endTime;
-  const totalRange = maxEnd - minStart;
-  const durationMs = endMs - startMs;
-  const startPercent = ((startMs - minStart) / totalRange) * 100;
-  const widthPercent = (durationMs / totalRange) * 100;
+  const { startPercent, widthPercent } = getTimelineData({
+    spanCard,
+    minStart,
+    maxEnd,
+  });
 
   return (
-    <span className="flex w-full items-center">
-      <span className="relative h-4 flex-1 rounded bg-gray-200 px-1 dark:bg-gray-900">
-        <span className="pointer-events-none absolute inset-x-1 top-1/2 h-1.5 -translate-y-1/2">
-          <span
-            className={`absolute h-full rounded-sm ${timelineBgColors[theme]}`}
-            style={{
-              left: `${startPercent}%`,
-              width: `${widthPercent}%`,
-            }}
-          />
-        </span>
-      </span>
-      <span className="ml-2 w-10 whitespace-nowrap text-right text-xs text-black dark:text-white">
-        {formatDuration(durationMs)}
+    <span className="relative h-4 min-w-16 flex-1 rounded bg-gray-200 dark:bg-gray-900">
+      <span className="pointer-events-none absolute inset-x-1 top-1/2 h-1.5 -translate-y-1/2">
+        <span
+          className={`absolute h-full rounded-sm ${timelineBgColors[theme]}`}
+          style={{
+            left: `${startPercent}%`,
+            width: `${widthPercent}%`,
+          }}
+        />
       </span>
     </span>
   );

--- a/packages/core/src/components/SpanCardToggle.tsx
+++ b/packages/core/src/components/SpanCardToggle.tsx
@@ -15,7 +15,7 @@ export const SpanCardToggle = ({
 }: SpanCardToggleProps) => (
   <Collapsible.Trigger asChild>
     <button
-      className="flex size-3 items-center justify-center"
+      className="flex size-3 shrink-0 items-center justify-center"
       onClick={onToggleClick}
       onKeyDown={onToggleClick}
       aria-label={`${isExpanded ? "Collapse" : "Expand"} ${title} children`}
@@ -23,9 +23,9 @@ export const SpanCardToggle = ({
       type="button"
     >
       {isExpanded ? (
-        <ChevronDown aria-hidden="true" className="text-gray-500" />
+        <ChevronDown aria-hidden="true" className="size-3 text-gray-500" />
       ) : (
-        <ChevronRight aria-hidden="true" className="text-gray-500" />
+        <ChevronRight aria-hidden="true" className="size-3 text-gray-500" />
       )}
     </button>
   </Collapsible.Trigger>

--- a/packages/core/src/components/TreeView.tsx
+++ b/packages/core/src/components/TreeView.tsx
@@ -30,6 +30,8 @@ export const TreeView: FC<TreeViewProps> = ({
     initialSelectedId,
   );
 
+  const [searchValue, setSearchValue] = useState("");
+
   const allCards = flattenSpans(spans);
 
   const { minStart, maxEnd } = findTimeRange(allCards);
@@ -45,10 +47,17 @@ export const TreeView: FC<TreeViewProps> = ({
 
   return (
     <div className={`border bg-white dark:bg-gray-950 ${className}`}>
-      <div className="flex items-center justify-between border-b p-3">
-        <SpanCardSearchInput onSearch={() => {}} />
+      <div className="flex items-center justify-between gap-2 border-b p-3">
+        <SpanCardSearchInput
+          name="search"
+          clearable
+          onClear={() => setSearchValue("")}
+          value={searchValue}
+          onValueChange={setSearchValue}
+          className="max-w-60 grow"
+        />
 
-        <div className="flex w-full items-center gap-2">
+        <div className="flex items-center gap-2">
           <div className="ml-auto flex items-center gap-3">
             <SpanCardExpandAllButton onExpandAll={() => {}} />
             <SpanCardCollapseAllButton onCollapseAll={() => {}} />

--- a/packages/core/src/services/get-timeline-data.test.ts
+++ b/packages/core/src/services/get-timeline-data.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect } from "vitest";
+
+import type { SpanCardType } from "../types/span";
+import { getTimelineData } from "./get-timeline-data";
+
+describe("getTimelineData", () => {
+  describe("basic functionality", () => {
+    it("should calculate timeline data for a span card within a time range", () => {
+      const spanCard: SpanCardType = {
+        id: "1",
+        title: "LLM Call",
+        startTime: new Date("2023-10-01T10:00:00.000Z"),
+        endTime: new Date("2023-10-01T10:00:30.000Z"),
+        duration: 30000,
+        cost: 0.002,
+        type: "llm_call",
+        tokensCount: 150,
+        status: "success",
+      };
+
+      const minStart = +new Date("2023-10-01T10:00:00.000Z");
+      const maxEnd = +new Date("2023-10-01T10:01:00.000Z");
+
+      const result = getTimelineData({ spanCard, minStart, maxEnd });
+
+      expect(result.durationMs).toBe(30000);
+      expect(result.startPercent).toBe(0);
+      expect(result.widthPercent).toBe(50);
+    });
+
+    it("should handle span cards that start after the minimum time", () => {
+      const spanCard: SpanCardType = {
+        id: "2",
+        title: "Tool Execution",
+        startTime: new Date("2023-10-01T10:00:30.000Z"),
+        endTime: new Date("2023-10-01T10:00:45.000Z"),
+        duration: 15000,
+        cost: 0.001,
+        type: "tool_execution",
+        tokensCount: 50,
+        status: "success",
+      };
+
+      const minStart = +new Date("2023-10-01T10:00:00.000Z");
+      const maxEnd = +new Date("2023-10-01T10:01:00.000Z");
+
+      const result = getTimelineData({ spanCard, minStart, maxEnd });
+
+      expect(result.durationMs).toBe(15000);
+      expect(result.startPercent).toBe(50);
+      expect(result.widthPercent).toBe(25);
+    });
+
+    it("should handle span cards that end before the maximum time", () => {
+      const spanCard: SpanCardType = {
+        id: "3",
+        title: "Agent Invocation",
+        startTime: new Date("2023-10-01T10:00:00.000Z"),
+        endTime: new Date("2023-10-01T10:00:20.000Z"),
+        duration: 20000,
+        cost: 0.003,
+        type: "agent_invocation",
+        tokensCount: 200,
+        status: "success",
+      };
+
+      const minStart = +new Date("2023-10-01T10:00:00.000Z");
+      const maxEnd = +new Date("2023-10-01T10:01:00.000Z");
+
+      const result = getTimelineData({ spanCard, minStart, maxEnd });
+
+      expect(result.durationMs).toBe(20000);
+      expect(result.startPercent).toBe(0);
+      expect(result.widthPercent).toBe(33.33333333333333);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle very short duration spans", () => {
+      const spanCard: SpanCardType = {
+        id: "4",
+        title: "Quick Operation",
+        startTime: new Date("2023-10-01T10:00:00.000Z"),
+        endTime: new Date("2023-10-01T10:00:00.001Z"),
+        duration: 1,
+        cost: 0.0001,
+        type: "chain_operation",
+        tokensCount: 10,
+        status: "success",
+      };
+
+      const minStart = +new Date("2023-10-01T10:00:00.000Z");
+      const maxEnd = +new Date("2023-10-01T10:00:01.000Z");
+
+      const result = getTimelineData({ spanCard, minStart, maxEnd });
+
+      expect(result.durationMs).toBe(1);
+      expect(result.startPercent).toBe(0);
+      expect(result.widthPercent).toBe(0.1);
+    });
+
+    it("should handle very long duration spans", () => {
+      const spanCard: SpanCardType = {
+        id: "5",
+        title: "Long Running Task",
+        startTime: new Date("2023-10-01T10:00:00.000Z"),
+        endTime: new Date("2023-10-01T10:00:59.000Z"),
+        duration: 59000,
+        cost: 0.005,
+        type: "retrieval",
+        tokensCount: 500,
+        status: "success",
+      };
+
+      const minStart = +new Date("2023-10-01T10:00:00.000Z");
+      const maxEnd = +new Date("2023-10-01T10:01:00.000Z");
+
+      const result = getTimelineData({ spanCard, minStart, maxEnd });
+
+      expect(result.durationMs).toBe(59000);
+      expect(result.startPercent).toBe(0);
+      expect(result.widthPercent).toBeCloseTo(98.33);
+    });
+
+    it("should handle spans that span the entire time range", () => {
+      const spanCard: SpanCardType = {
+        id: "6",
+        title: "Full Range Span",
+        startTime: new Date("2023-10-01T10:00:00.000Z"),
+        endTime: new Date("2023-10-01T10:01:00.000Z"),
+        duration: 60000,
+        cost: 0.01,
+        type: "embedding",
+        tokensCount: 1000,
+        status: "success",
+      };
+
+      const minStart = +new Date("2023-10-01T10:00:00.000Z");
+      const maxEnd = +new Date("2023-10-01T10:01:00.000Z");
+
+      const result = getTimelineData({ spanCard, minStart, maxEnd });
+
+      expect(result.durationMs).toBe(60000);
+      expect(result.startPercent).toBe(0);
+      expect(result.widthPercent).toBe(100);
+    });
+
+    it("should handle spans that are exactly at the boundaries", () => {
+      const spanCard: SpanCardType = {
+        id: "7",
+        title: "Boundary Span",
+        startTime: new Date("2023-10-01T10:00:00.000Z"),
+        endTime: new Date("2023-10-01T10:00:00.000Z"),
+        duration: 0,
+        cost: 0,
+        type: "unknown",
+        tokensCount: 0,
+        status: "success",
+      };
+
+      const minStart = +new Date("2023-10-01T10:00:00.000Z");
+      const maxEnd = +new Date("2023-10-01T10:00:01.000Z");
+
+      const result = getTimelineData({ spanCard, minStart, maxEnd });
+
+      expect(result.durationMs).toBe(0);
+      expect(result.startPercent).toBe(0);
+      expect(result.widthPercent).toBe(0);
+    });
+  });
+
+  describe("percentage calculations", () => {
+    it("should calculate start percentage correctly for various positions", () => {
+      const minStart = +new Date("2023-10-01T10:00:00.000Z");
+      const maxEnd = +new Date("2023-10-01T10:01:00.000Z");
+
+      // Test at 25% of the timeline
+      const spanCard1: SpanCardType = {
+        id: "8",
+        title: "25% Position",
+        startTime: new Date("2023-10-01T10:00:15.000Z"),
+        endTime: new Date("2023-10-01T10:00:20.000Z"),
+        duration: 5000,
+        cost: 0.001,
+        type: "llm_call",
+        tokensCount: 100,
+        status: "success",
+      };
+
+      const result1 = getTimelineData({
+        spanCard: spanCard1,
+        minStart,
+        maxEnd,
+      });
+      expect(result1.startPercent).toBe(25);
+
+      // Test at 75% of the timeline
+      const spanCard2: SpanCardType = {
+        id: "9",
+        title: "75% Position",
+        startTime: new Date("2023-10-01T10:00:45.000Z"),
+        endTime: new Date("2023-10-01T10:00:50.000Z"),
+        duration: 5000,
+        cost: 0.001,
+        type: "tool_execution",
+        tokensCount: 100,
+        status: "success",
+      };
+
+      const result2 = getTimelineData({
+        spanCard: spanCard2,
+        minStart,
+        maxEnd,
+      });
+      expect(result2.startPercent).toBe(75);
+    });
+
+    it("should calculate width percentage correctly for various durations", () => {
+      const minStart = +new Date("2023-10-01T10:00:00.000Z");
+      const maxEnd = +new Date("2023-10-01T10:01:00.000Z");
+
+      // Test 10% width
+      const spanCard1: SpanCardType = {
+        id: "10",
+        title: "10% Width",
+        startTime: new Date("2023-10-01T10:00:00.000Z"),
+        endTime: new Date("2023-10-01T10:00:06.000Z"),
+        duration: 6000,
+        cost: 0.001,
+        type: "chain_operation",
+        tokensCount: 100,
+        status: "success",
+      };
+
+      const result1 = getTimelineData({
+        spanCard: spanCard1,
+        minStart,
+        maxEnd,
+      });
+      expect(result1.widthPercent).toBe(10);
+
+      // Test 20% width
+      const spanCard2: SpanCardType = {
+        id: "11",
+        title: "20% Width",
+        startTime: new Date("2023-10-01T10:00:00.000Z"),
+        endTime: new Date("2023-10-01T10:00:12.000Z"),
+        duration: 12000,
+        cost: 0.002,
+        type: "retrieval",
+        tokensCount: 200,
+        status: "success",
+      };
+
+      const result2 = getTimelineData({
+        spanCard: spanCard2,
+        minStart,
+        maxEnd,
+      });
+      expect(result2.widthPercent).toBe(20);
+    });
+  });
+
+  describe("time range variations", () => {
+    it("should handle different time range scales", () => {
+      const spanCard: SpanCardType = {
+        id: "15",
+        title: "Micro Operation",
+        startTime: new Date("2023-10-01T10:00:00.000Z"),
+        endTime: new Date("2023-10-01T10:00:00.100Z"),
+        duration: 100,
+        cost: 0.00001,
+        type: "chain_operation",
+        tokensCount: 5,
+        status: "success",
+      };
+
+      // 1 second range
+      const minStart1 = +new Date("2023-10-01T10:00:00.000Z");
+      const maxEnd1 = +new Date("2023-10-01T10:00:01.000Z");
+      const result1 = getTimelineData({
+        spanCard,
+        minStart: minStart1,
+        maxEnd: maxEnd1,
+      });
+      expect(result1.widthPercent).toBe(10);
+
+      // 100 millisecond range
+      const minStart2 = +new Date("2023-10-01T10:00:00.000Z");
+      const maxEnd2 = +new Date("2023-10-01T10:00:00.200Z");
+      const result2 = getTimelineData({
+        spanCard,
+        minStart: minStart2,
+        maxEnd: maxEnd2,
+      });
+      expect(result2.widthPercent).toBe(50);
+    });
+
+    it("should handle very large time ranges", () => {
+      const spanCard: SpanCardType = {
+        id: "16",
+        title: "Long Running Process",
+        startTime: new Date("2023-10-01T10:00:00.000Z"),
+        endTime: new Date("2023-10-01T10:05:00.000Z"),
+        duration: 300000,
+        cost: 0.05,
+        type: "embedding",
+        tokensCount: 5000,
+        status: "success",
+      };
+
+      // 1 hour range
+      const minStart = +new Date("2023-10-01T10:00:00.000Z");
+      const maxEnd = +new Date("2023-10-01T11:00:00.000Z");
+
+      const result = getTimelineData({ spanCard, minStart, maxEnd });
+
+      expect(result.durationMs).toBe(300000);
+      expect(result.startPercent).toBe(0);
+      expect(result.widthPercent).toBeCloseTo(8.33);
+    });
+  });
+
+  describe("precision and floating point handling", () => {
+    it("should handle precise timing calculations", () => {
+      const spanCard: SpanCardType = {
+        id: "17",
+        title: "Precise Operation",
+        startTime: new Date("2023-10-01T10:00:00.000Z"),
+        endTime: new Date("2023-10-01T10:00:00.001Z"),
+        duration: 1,
+        cost: 0.000001,
+        type: "unknown",
+        tokensCount: 1,
+        status: "success",
+      };
+
+      const minStart = +new Date("2023-10-01T10:00:00.000Z");
+      const maxEnd = +new Date("2023-10-01T10:00:00.010Z");
+
+      const result = getTimelineData({ spanCard, minStart, maxEnd });
+
+      expect(result.durationMs).toBe(1);
+      expect(result.startPercent).toBe(0);
+      expect(result.widthPercent).toBe(10);
+    });
+
+    it("should handle edge case where span duration equals total range", () => {
+      const spanCard: SpanCardType = {
+        id: "18",
+        title: "Full Range Span",
+        startTime: new Date("2023-10-01T10:00:00.000Z"),
+        endTime: new Date("2023-10-01T10:00:01.000Z"),
+        duration: 1000,
+        cost: 0.001,
+        type: "llm_call",
+        tokensCount: 100,
+        status: "success",
+      };
+
+      const minStart = +new Date("2023-10-01T10:00:00.000Z");
+      const maxEnd = +new Date("2023-10-01T10:00:01.000Z");
+
+      const result = getTimelineData({ spanCard, minStart, maxEnd });
+
+      expect(result.durationMs).toBe(1000);
+      expect(result.startPercent).toBe(0);
+      expect(result.widthPercent).toBe(100);
+    });
+  });
+});

--- a/packages/core/src/services/get-timeline-data.ts
+++ b/packages/core/src/services/get-timeline-data.ts
@@ -1,0 +1,24 @@
+import type { SpanCardType } from "../types/span";
+
+export const getTimelineData = ({
+  spanCard,
+  minStart,
+  maxEnd,
+}: {
+  spanCard: SpanCardType;
+  minStart: number;
+  maxEnd: number;
+}) => {
+  const startMs = +spanCard.startTime;
+  const endMs = +spanCard.endTime;
+  const totalRange = maxEnd - minStart;
+  const durationMs = endMs - startMs;
+  const startPercent = ((startMs - minStart) / totalRange) * 100;
+  const widthPercent = (durationMs / totalRange) * 100;
+
+  return {
+    durationMs,
+    startPercent,
+    widthPercent,
+  };
+};


### PR DESCRIPTION
Mobile version generally looks much nicer now, but some additional work has to be done. Mostly regarding correct placement of arrows and connectors - it turned out to be quite a pain in the ass to align them all in correct way with support for all possible widths and heights. I'm 95% there but there are a few bugs:

<img width="436" height="277" alt="image" src="https://github.com/user-attachments/assets/2bb3fe91-65c4-4678-b905-c0ce8bff04b5" />

<img width="356" height="182" alt="image" src="https://github.com/user-attachments/assets/33766ff3-08ec-45aa-8b12-9a5571d78107" />

I've decided to address this in further PR since this one is growing kind of big. 

Also we will need to test it with arbitrary/big nesting (preferably 10 levels or so).

Other than that, it looks much much better on small width right now:

<img width="496" height="438" alt="image" src="https://github.com/user-attachments/assets/1b93ad76-4f20-48ba-8c64-196e7a61585a" />

<img width="542" height="257" alt="image" src="https://github.com/user-attachments/assets/7c0e7f7f-451e-4620-8c96-32ccd8710c73" />

<img width="356" height="395" alt="image" src="https://github.com/user-attachments/assets/dc80079d-1e8c-4404-9998-c092ec02d779" />

P.S. i did not 100% follow the design, instead i tried to find a good middleground, where it looks good, fluidly updates with the width change, and at the same time is kinda easy to implement 