### PR TITLE
Whanou/price badges

### DIFF
--- a/packages/core/src/components/Badge.tsx
+++ b/packages/core/src/components/Badge.tsx
@@ -76,12 +76,12 @@ export const Badge = ({
 
   return (
     <span
-      className={`max-w-112 inline-flex min-w-fit items-center truncate rounded font-medium ${variantClasses} ${sizeClasses[size]} ${className}`}
+      className={`inline-flex min-w-0 items-center overflow-hidden rounded font-medium ${variantClasses} ${sizeClasses[size]} ${className}`}
     >
       {iconStart && <span className="shrink-0">{iconStart}</span>}
 
       <span
-        className={`${textSizes[size]} min-w-0 flex-shrink-0 tracking-normal`}
+        className={`${textSizes[size]} min-w-0 max-w-full flex-shrink-0 truncate tracking-normal`}
       >
         {children}
       </span>

--- a/packages/core/src/components/PriceBadge.tsx
+++ b/packages/core/src/components/PriceBadge.tsx
@@ -1,0 +1,14 @@
+import { Badge, type BadgeProps } from "./Badge";
+
+interface PriceBadgeProps {
+  cost: number;
+  size?: BadgeProps["size"];
+}
+
+export const PriceBadge = ({ cost, size = "xs" }: PriceBadgeProps) => {
+  return (
+    <Badge theme="gray" size={size}>
+      $ {cost}
+    </Badge>
+  );
+};

--- a/packages/core/src/components/SpanCardBadges.tsx
+++ b/packages/core/src/components/SpanCardBadges.tsx
@@ -26,9 +26,11 @@ export const SpanCardBadges = ({ data }: SpanCardBagdesProps) => {
         {getSpanCategoryLabel(data.type)}
       </Badge>
 
-      <TokensBadge tokensCount={data.tokensCount} />
+      {typeof data.tokensCount === "number" && (
+        <TokensBadge tokensCount={data.tokensCount} />
+      )}
 
-      <PriceBadge cost={data.cost} />
+      {typeof data.cost === "number" && <PriceBadge cost={data.cost} />}
     </div>
   );
 };

--- a/packages/core/src/components/SpanCardBadges.tsx
+++ b/packages/core/src/components/SpanCardBadges.tsx
@@ -1,5 +1,3 @@
-import { Coins } from "lucide-react";
-
 import type { TraceSpan } from "../types";
 
 import {
@@ -8,6 +6,8 @@ import {
   getSpanCategoryTheme,
 } from "../utils/ui";
 import { Badge } from "./Badge";
+import { PriceBadge } from "./PriceBadge";
+import { TokensBadge } from "./TokensBadge";
 
 interface SpanCardBagdesProps {
   data: TraceSpan;
@@ -26,13 +26,9 @@ export const SpanCardBadges = ({ data }: SpanCardBagdesProps) => {
         {getSpanCategoryLabel(data.type)}
       </Badge>
 
-      <Badge iconStart={<Coins className="size-2.5" />} theme="gray" size="xs">
-        {data.tokensCount}
-      </Badge>
+      <TokensBadge tokensCount={data.tokensCount} />
 
-      <Badge theme="gray" size="xs">
-        $ {data.cost}
-      </Badge>
+      <PriceBadge cost={data.cost} />
     </div>
   );
 };

--- a/packages/core/src/components/TokensBadge.tsx
+++ b/packages/core/src/components/TokensBadge.tsx
@@ -1,0 +1,16 @@
+import { Coins } from "lucide-react";
+
+import { Badge, type BadgeProps } from "./Badge";
+
+interface TokensBadgeProps {
+  tokensCount: number;
+  size?: BadgeProps["size"];
+}
+
+export const TokensBadge = ({ tokensCount, size = "xs" }: TokensBadgeProps) => {
+  return (
+    <Badge iconStart={<Coins className="size-2.5" />} theme="gray" size={size}>
+      {tokensCount}
+    </Badge>
+  );
+};

--- a/packages/core/src/components/TraceListItem.tsx
+++ b/packages/core/src/components/TraceListItem.tsx
@@ -6,6 +6,8 @@ import type { TraceRecord } from "../types";
 import { formatDuration } from "../services/calculate-duration";
 import { Avatar, type AvatarProps } from "./Avatar";
 import { Badge, type BadgeProps } from "./Badge";
+import { PriceBadge } from "./PriceBadge";
+import { TokensBadge } from "./TokensBadge";
 
 interface TraceListItemProps extends TraceRecord {
   badges?: Array<BadgeProps>;
@@ -20,6 +22,8 @@ export const TraceListItem = ({
   agentDescription,
   avatar,
   onClick,
+  totalCost,
+  totalTokens,
   badges,
 }: TraceListItemProps) => {
   const handleKeyDown = useCallback(
@@ -71,6 +75,12 @@ export const TraceListItem = ({
         <span className="mr-4 max-w-full truncate text-sm text-gray-600 dark:text-gray-400">
           {agentDescription}
         </span>
+
+        {typeof totalCost === "number" && <PriceBadge cost={totalCost} />}
+
+        {typeof totalTokens === "number" && (
+          <TokensBadge tokensCount={totalTokens} />
+        )}
 
         {badges?.map((badge, index) => (
           <Badge key={index} theme={badge.theme} size="xs">

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,12 @@ export { default as CollapsibleSectionSource } from "./components/CollapsibleSec
 export { IconButton } from "./components/IconButton";
 export { default as IconButtonSource } from "./components/IconButton.tsx?raw";
 
+export { PriceBadge } from "./components/PriceBadge";
+export { default as PriceBadgeSource } from "./components/PriceBadge.tsx?raw";
+
+export { TokensBadge } from "./components/TokensBadge";
+export { default as TokensBadgeSource } from "./components/TokensBadge.tsx?raw";
+
 export { SpanCard } from "./components/SpanCard.tsx";
 
 export { TextInput } from "./components/TextInput.tsx";

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -18,13 +18,13 @@ export type TraceSpan = {
   startTime: Date;
   endTime: Date;
   duration: number;
-  cost: number;
   type: TraceSpanCategory;
   raw: string;
   attributes: SpanAttribute[];
   children?: TraceSpan[];
-  tokensCount: number;
   status: TraceSpanStatus;
+  cost?: number;
+  tokensCount?: number;
 };
 
 export type TraceSpanCategory =

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -6,6 +6,8 @@ export type TraceRecord = {
   spansCount: number;
   durationMs: number;
   agentDescription: string;
+  totalCost?: number;
+  totalTokens?: number;
 };
 
 export type TraceSpanStatus = "success" | "error" | "pending" | "warning";

--- a/packages/sandbox/src/pages/TraceListPage.tsx
+++ b/packages/sandbox/src/pages/TraceListPage.tsx
@@ -11,6 +11,8 @@ const traces: TraceRecord[] = [
     spansCount: 10,
     durationMs: 10_000,
     agentDescription: "research-agent",
+    totalCost: 100,
+    totalTokens: 1000,
     // badges: [
     //   {
     //     children: "app:dev-chatbot",
@@ -37,6 +39,8 @@ const traces: TraceRecord[] = [
     spansCount: 100,
     durationMs: 100_000,
     agentDescription: "data-analysis-bot",
+    totalCost: 1,
+    totalTokens: 1000000,
     // badges: [
     //   {
     //     children: "app: staging-assistant",

--- a/packages/storybook/src/stories/PriceBagde.stories.tsx
+++ b/packages/storybook/src/stories/PriceBagde.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PriceBadge, PriceBadgeSource } from "ai-agent-trace-ui-core";
+
+const meta = {
+  title: "Components/PriceBadge",
+  component: PriceBadge,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `
+\`\`\`tsx
+${PriceBadgeSource}
+\`\`\`
+        `,
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    cost: {
+      control: { type: "number" },
+      description: "The cost amount to display",
+      defaultValue: 0.5,
+    },
+    size: {
+      control: { type: "select" },
+      options: ["xs", "sm", "md"],
+      description: "The size of the badge",
+      defaultValue: "xs",
+    },
+  },
+} satisfies Meta<typeof PriceBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    cost: 0.5,
+  },
+};
+
+export const Small: Story = {
+  args: {
+    cost: 1.25,
+    size: "sm",
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    cost: 2.99,
+    size: "md",
+  },
+};

--- a/packages/storybook/src/stories/TokensBadge.stories.tsx
+++ b/packages/storybook/src/stories/TokensBadge.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { TokensBadge } from "ai-agent-trace-ui-core";
+
+const TokensBadgeSource = `
+import { Coins } from "lucide-react";
+
+import { Badge, type BadgeProps } from "./Badge";
+
+interface TokensBadgeProps {
+  tokensCount: number;
+  size?: BadgeProps["size"];
+}
+
+export const TokensBadge = ({ tokensCount, size = "xs" }: TokensBadgeProps) => {
+  return (
+    <Badge iconStart={<Coins className="size-2.5" />} theme="gray" size={size}>
+      {tokensCount}
+    </Badge>
+  );
+};
+`;
+
+const meta = {
+  title: "Components/TokensBadge",
+  component: TokensBadge,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `
+\`\`\`tsx
+${TokensBadgeSource}
+\`\`\`
+        `,
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    tokensCount: {
+      control: { type: "number" },
+      description: "The number of tokens to display",
+      defaultValue: 1500,
+    },
+    size: {
+      control: { type: "select" },
+      options: ["xs", "sm", "md"],
+      description: "The size of the badge",
+      defaultValue: "xs",
+    },
+  },
+} satisfies Meta<typeof TokensBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    tokensCount: 1500,
+  },
+};
+
+export const Small: Story = {
+  args: {
+    tokensCount: 2500,
+    size: "sm",
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    tokensCount: 5000,
+    size: "md",
+  },
+};
+
+export const LargeTokenCount: Story = {
+  args: {
+    tokensCount: 15000,
+    size: "md",
+  },
+};


### PR DESCRIPTION
Closes #45 #46 

### Changes
- Moved tokens/price badges to a separate component
- Added them to TraceListItem as well
- Updated styles of Badge a little to prevent potential overflow

Before:
<img width="482" height="416" alt="image" src="https://github.com/user-attachments/assets/f4f78e28-0598-4ca4-abd1-bd82072ad890" />

After:
<img width="413" height="411" alt="image" src="https://github.com/user-attachments/assets/b2eb14fb-bf41-4f91-84f5-928169662da9" />
