### PR TITLE
Whanou/search input adjustments

### DIFF
--- a/packages/storybook/src/stories/TextInput.stories.tsx
+++ b/packages/storybook/src/stories/TextInput.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { TextInput, TextInputSource } from "@ai-agent-trace-ui/ui";
+import {
+  TextInput,
+  TextInputSource,
+  type TextInputProps,
+} from "@ai-agent-trace-ui/ui";
+import { useState } from "react";
 
 const meta = {
   title: "Components/TextInput",
@@ -85,8 +90,18 @@ export const Clearable: Story = {
     id: "clearable-input",
     label: "Email",
     placeholder: "Enter email...",
-    clearable: true,
     defaultValue: "example@domain.com",
+  },
+  render: (args: TextInputProps) => {
+    const [value, setValue] = useState(args.defaultValue);
+    return (
+      <TextInput
+        {...args}
+        value={value}
+        onValueChange={setValue}
+        onClear={() => setValue("")}
+      />
+    );
   },
 };
 

--- a/packages/storybook/src/stories/TextInput.stories.tsx
+++ b/packages/storybook/src/stories/TextInput.stories.tsx
@@ -42,11 +42,6 @@ ${TextInputSource}
         "Whether to visually hide the label while keeping it for screen readers",
       defaultValue: false,
     },
-    clearable: {
-      control: "boolean",
-      description: "Whether to show a clear button when input has value",
-      defaultValue: true,
-    },
     disabled: {
       control: "boolean",
       description: "Disables the input",

--- a/packages/ui/src/components/DetailsView/DetailsViewAttributesTab.tsx
+++ b/packages/ui/src/components/DetailsView/DetailsViewAttributesTab.tsx
@@ -27,7 +27,6 @@ export const DetailsViewAttributesTab = ({ data }: AttributesTabProps) => (
             value={value}
             disabled
             readOnly
-            clearable={false}
             inputClassName="font-mono text-xs"
             className="w-full"
           />

--- a/packages/ui/src/components/SearchInput.tsx
+++ b/packages/ui/src/components/SearchInput.tsx
@@ -2,7 +2,11 @@ import { Search } from "lucide-react";
 
 import { TextInput, type TextInputProps } from "./TextInput.tsx";
 
-export const SpanCardSearchInput = ({ ...props }: TextInputProps) => {
+/**
+ * A simple wrapper around the TextInput component.
+ * It adds a search icon and a placeholder.
+ */
+export const SearchInput = ({ ...props }: TextInputProps) => {
   return (
     <TextInput
       startIcon={<Search className="size-4" />}

--- a/packages/ui/src/components/TextInput.tsx
+++ b/packages/ui/src/components/TextInput.tsx
@@ -20,15 +20,10 @@ export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
   startIcon?: ReactNode;
 
   /**
-   * Callback fired when the clear button is clicked
+   * Callback fired when the clear button is clicked. If this callback is provided,
+   * the clear button will be shown.
    */
   onClear?: () => void;
-
-  /**
-   * Whether to show a clear button when input has value
-   * @default false
-   */
-  clearable?: boolean;
 
   /**
    * Ref to the input element
@@ -66,7 +61,6 @@ export const TextInput = ({
   onValueChange,
   startIcon,
   onClear,
-  clearable = true,
   ref,
   inputClassName,
   label,
@@ -133,7 +127,7 @@ export const TextInput = ({
             {startIcon}
           </div>
         )}
-        {onClear && clearable && (
+        {onClear && props.value && (
           <button
             className={cn(iconBaseClassName, "right-2")}
             aria-label="Clear input value"

--- a/packages/ui/src/components/TraceViewer.tsx
+++ b/packages/ui/src/components/TraceViewer.tsx
@@ -5,7 +5,7 @@ import {
   DetailsView,
   SpanCardCollapseAllButton,
   SpanCardExpandAllButton,
-  SpanCardSearchInput,
+  SearchInput,
   TraceList,
   TraceListItemHeader,
   TreeView,
@@ -200,7 +200,7 @@ const DesktopLayout = ({
 
           <div className="border border-gray-200 bg-white dark:border-gray-600 dark:bg-gray-950">
             <div className="flex items-center justify-between gap-2 border-b border-gray-200 p-3 dark:border-gray-600">
-              <SpanCardSearchInput
+              <SearchInput
                 id="span-search"
                 name="search"
                 onClear={() => setSearchValue("")}
@@ -298,7 +298,7 @@ const MobileLayout = ({
 
         <div className="border border-gray-200 bg-white dark:border-gray-600 dark:bg-gray-950">
           <div className="flex items-center justify-between gap-2 border-b border-gray-200 p-3 dark:border-gray-600">
-            <SpanCardSearchInput
+            <SearchInput
               id="span-search"
               name="search"
               onClear={() => setSearchValue("")}

--- a/packages/ui/src/components/TraceViewer.tsx
+++ b/packages/ui/src/components/TraceViewer.tsx
@@ -203,7 +203,6 @@ const DesktopLayout = ({
               <SpanCardSearchInput
                 id="span-search"
                 name="search"
-                clearable
                 onClear={() => setSearchValue("")}
                 value={searchValue}
                 onValueChange={setSearchValue}
@@ -302,7 +301,6 @@ const MobileLayout = ({
             <SpanCardSearchInput
               id="span-search"
               name="search"
-              clearable
               onClear={() => setSearchValue("")}
               value={searchValue}
               onValueChange={setSearchValue}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -22,7 +22,7 @@ export { default as TokensBadgeSource } from "./components/TokensBadge.tsx?raw";
 export { SpanCard } from "./components/SpanCard.tsx";
 export { SpanCardCollapseAllButton } from "./components/SpanCardControls.tsx";
 export { SpanCardExpandAllButton } from "./components/SpanCardControls.tsx";
-export { SpanCardSearchInput } from "./components/SpanCardSearchInput.tsx";
+export { SearchInput } from "./components/SearchInput.tsx";
 
 export { TextInput } from "./components/TextInput.tsx";
 export { default as TextInputSource } from "./components/TextInput.tsx?raw";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -24,7 +24,7 @@ export { SpanCardCollapseAllButton } from "./components/SpanCardControls.tsx";
 export { SpanCardExpandAllButton } from "./components/SpanCardControls.tsx";
 export { SearchInput } from "./components/SearchInput.tsx";
 
-export { TextInput } from "./components/TextInput.tsx";
+export { TextInput, type TextInputProps } from "./components/TextInput.tsx";
 export { default as TextInputSource } from "./components/TextInput.tsx?raw";
 
 export { TreeView } from "./components/TreeView";


### PR DESCRIPTION
Closes #62 

### Changes
- Renamed `SpanCardSearchInput` to just `SearchInput`. I think it makes much more sense since it's not strictly tied to `SpanCard` and can be user anywhere
- Removed `clearable` prop - there's no reason to duplicate logic, in `onClear` is provided we will just display the button
- Made clear button only visible when there's a non-empty value