### PR TITLE
fix: incorrect margins between title and badges

### DIFF
--- a/packages/ui/src/components/SpanCard.tsx
+++ b/packages/ui/src/components/SpanCard.tsx
@@ -382,7 +382,7 @@ export const SpanCard: FC<SpanCardProps> = ({
               {avatar && <Avatar {...avatar} />}
 
               <h3
-                className="mr-3 h-4 max-w-32 grow truncate text-sm leading-[14px] text-gray-900 dark:text-gray-200"
+                className="mr-1 h-4 max-w-32 truncate text-sm leading-[14px] text-gray-900 dark:text-gray-200"
                 title={data.title}
               >
                 {data.title}


### PR DESCRIPTION
Closes #63 

Before:
<img width="428" height="221" alt="image" src="https://github.com/user-attachments/assets/f44b25ec-6ccc-4a67-a6fc-2c665fa590e5" />

After:
<img width="449" height="309" alt="image" src="https://github.com/user-attachments/assets/dc31cacf-7ffa-4ab7-996c-bb857a06faf1" />