### PR TITLE
Whanou/small improvements

### DIFF
--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -2,6 +2,8 @@ import type { Preview } from "@storybook/react-vite";
 
 import "@ai-agent-trace-ui/ui/styles.css";
 
+import "./styles.css";
+
 const preview: Preview = {
   parameters: {
     options: {

--- a/packages/storybook/.storybook/styles.css
+++ b/packages/storybook/.storybook/styles.css
@@ -1,0 +1,11 @@
+.sb-show-main,
+.docs-story {
+  background-color: white;
+}
+
+@media (prefers-color-scheme: dark) {
+  .sb-show-main,
+  .docs-story {
+    background-color: black;
+  }
+}

--- a/packages/storybook/src/stories/Avatar.stories.tsx
+++ b/packages/storybook/src/stories/Avatar.stories.tsx
@@ -127,3 +127,10 @@ export const Rounded: Story = {
     rounded: "none",
   },
 };
+
+export const FailedToLoad: Story = {
+  args: {
+    alt: "Failed to load",
+    src: "that-does-not-exist.jpg",
+  },
+};

--- a/packages/storybook/src/stories/CollapsibleSection.stories.tsx
+++ b/packages/storybook/src/stories/CollapsibleSection.stories.tsx
@@ -29,6 +29,19 @@ const meta = {
       ),
     },
   },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          width: "360px",
+          maxWidth: "100%",
+          minHeight: "120px",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
   tags: ["autodocs"],
   argTypes: {
     title: {

--- a/packages/storybook/src/stories/Tabs.stories.tsx
+++ b/packages/storybook/src/stories/Tabs.stories.tsx
@@ -26,6 +26,13 @@ const meta = {
       ),
     },
   },
+  decorators: [
+    (Story) => (
+      <div style={{ width: "360px", maxWidth: "100%" }}>
+        <Story />
+      </div>
+    ),
+  ],
   tags: ["autodocs"],
   argTypes: {
     items: {

--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -1,13 +1,23 @@
-import type { ReactElement } from "react";
+import cn from "classnames";
+import { User } from "lucide-react";
+import { useState, type ReactElement } from "react";
 
 import { ROUNDED_CLASSES, type ColorVariant } from "./shared.ts";
 
 const sizeClasses = {
-  xs: "w-4 h-4 text-xs",
-  sm: "w-5 h-5 text-sm",
-  md: "w-8 h-8 text-base",
-  lg: "w-10 h-10 text-lg",
-  xl: "w-12 h-12 text-xl",
+  xs: "size-4 text-xs",
+  sm: "size-5 text-sm",
+  md: "size-8 text-base",
+  lg: "size-10 text-lg",
+  xl: "size-12 text-xl",
+};
+
+const iconSizeClasses = {
+  xs: "size-3",
+  sm: "size-4",
+  md: "size-6",
+  lg: "size-8",
+  xl: "size-10",
 };
 
 const textSizeClasses = {
@@ -81,22 +91,53 @@ export const Avatar = ({
   letter,
   className = "",
 }: AvatarProps): ReactElement => {
+  const [error, setError] = useState(false);
+
   const displayLetter = letter ? letter.charAt(0) : alt.charAt(0).toUpperCase();
 
   const actualTextColor = textColor === "white" ? "text-white" : "text-black";
 
   return (
     <div
-      className={`overflow-hidden ${sizeClasses[size]} ${textSizeClasses[size]} ${ROUNDED_CLASSES[rounded]} ${className}`}
+      className={cn(
+        "flex items-center justify-center overflow-hidden",
+        "bg-gray-200 dark:bg-gray-700",
+        error && "border border-gray-300 dark:border-gray-600",
+        sizeClasses[size],
+        textSizeClasses[size],
+        ROUNDED_CLASSES[rounded],
+        className,
+      )}
     >
-      {src ? (
-        <img src={src} alt={alt} className="h-full w-full object-cover" />
+      {error ? (
+        <User
+          className={cn(
+            iconSizeClasses[size],
+            "text-gray-600 dark:text-gray-400",
+          )}
+        />
       ) : (
-        <div
-          className={`flex h-full w-full items-center justify-center ${bgColorClasses[bgColor]} ${actualTextColor} font-medium`}
-        >
-          {displayLetter}
-        </div>
+        <>
+          {src ? (
+            <img
+              src={src}
+              alt={alt}
+              className="h-full w-full object-cover"
+              onError={() => setError(true)}
+            />
+          ) : (
+            <div
+              className={cn(
+                "flex h-full w-full items-center justify-center",
+                bgColorClasses[bgColor],
+                actualTextColor,
+                "font-medium",
+              )}
+            >
+              {displayLetter}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -1,6 +1,6 @@
 import cn from "classnames";
 import { User } from "lucide-react";
-import { useState, type ReactElement } from "react";
+import { useState, type ComponentPropsWithRef, type ReactElement } from "react";
 
 import { ROUNDED_CLASSES, type ColorVariant } from "./shared.ts";
 
@@ -41,7 +41,7 @@ const bgColorClasses: Record<ColorVariant, string> = {
   emerald: "bg-emerald-600",
 };
 
-export type AvatarProps = {
+export type AvatarProps = ComponentPropsWithRef<"div"> & {
   /**
    * The image source for the avatar
    */
@@ -90,6 +90,7 @@ export const Avatar = ({
   textColor = "white",
   letter,
   className = "",
+  ...rest
 }: AvatarProps): ReactElement => {
   const [error, setError] = useState(false);
 
@@ -108,6 +109,7 @@ export const Avatar = ({
         ROUNDED_CLASSES[rounded],
         className,
       )}
+      {...rest}
     >
       {error ? (
         <User

--- a/packages/ui/src/components/Badge.tsx
+++ b/packages/ui/src/components/Badge.tsx
@@ -1,4 +1,6 @@
-import type { ReactElement, ReactNode } from "react";
+import type { ComponentPropsWithRef, ReactElement, ReactNode } from "react";
+
+import cn from "classnames";
 
 import { COLOR_THEME_CLASSES, type ColorVariant } from "./shared.ts";
 
@@ -15,7 +17,7 @@ const textSizes = {
   md: "text-sm font-medium",
 };
 
-export type BadgeProps = {
+export type BadgeProps = ComponentPropsWithRef<"span"> & {
   /**
    * The content of the badge
    */
@@ -64,6 +66,7 @@ export const Badge = ({
   iconStart,
   iconEnd,
   className = "",
+  ...rest
 }: BadgeProps): ReactElement => {
   const { bg, darkBg, text, darkText } = COLOR_THEME_CLASSES[theme];
 
@@ -74,12 +77,21 @@ export const Badge = ({
 
   return (
     <span
-      className={`inline-flex min-w-0 items-center overflow-hidden rounded font-medium ${variantClasses} ${sizeClasses[size]} ${className}`}
+      className={cn(
+        "inline-flex min-w-0 items-center overflow-hidden rounded font-medium",
+        variantClasses,
+        sizeClasses[size],
+        className,
+      )}
+      {...rest}
     >
       {iconStart && <span className="shrink-0">{iconStart}</span>}
 
       <span
-        className={`${textSizes[size]} min-w-0 max-w-full flex-shrink-0 truncate tracking-normal`}
+        className={cn(
+          textSizes[size],
+          "min-w-0 max-w-full flex-shrink-0 truncate tracking-normal",
+        )}
       >
         {children}
       </span>

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,4 +1,6 @@
-import type { FC, PropsWithChildren, ReactElement } from "react";
+import type { ComponentPropsWithRef, ReactElement } from "react";
+
+import cn from "classnames";
 
 import { ROUNDED_CLASSES, type ColorVariant } from "./shared.ts";
 
@@ -30,12 +32,7 @@ const variantClasses = {
   ghost: "bg-transparent text-gray-600 dark:text-gray-300",
 };
 
-export type ButtonProps = {
-  /**
-   * The content of the button
-   */
-  children: React.ReactNode;
-
+export type ButtonProps = ComponentPropsWithRef<"button"> & {
   /**
    * The size of the button
    * @default "xs"
@@ -67,12 +64,6 @@ export type ButtonProps = {
   fullWidth?: boolean;
 
   /**
-   * Disables the button
-   * @default false
-   */
-  disabled?: boolean;
-
-  /**
    * Optional icon to display at the start of the button
    */
   iconStart?: ReactElement;
@@ -81,25 +72,9 @@ export type ButtonProps = {
    * Optional icon to display at the end of the button
    */
   iconEnd?: ReactElement;
-
-  /**
-   * The button type attribute
-   * @default "button"
-   */
-  type?: "button" | "submit" | "reset";
-
-  /**
-   * Click handler function
-   */
-  onClick?: () => void;
-
-  /**
-   * Optional className for additional styling
-   */
-  className?: string;
 };
 
-export const Button: FC<PropsWithChildren<ButtonProps>> = ({
+export const Button = ({
   children,
   size = "xs",
   theme = "gray",
@@ -112,7 +87,8 @@ export const Button: FC<PropsWithChildren<ButtonProps>> = ({
   type = "button",
   onClick,
   className = "",
-}) => {
+  ...rest
+}: ButtonProps) => {
   const widthClass = fullWidth ? "w-full" : "";
   const stateClasses = disabled
     ? "cursor-not-allowed opacity-50"
@@ -127,7 +103,17 @@ export const Button: FC<PropsWithChildren<ButtonProps>> = ({
       type={type}
       onClick={onClick}
       disabled={disabled}
-      className={`${BASE_CLASSES} ${sizeClasses[size]} ${ROUNDED_CLASSES[rounded]} ${variantClasses[variant]} ${filledThemeClass} ${widthClass} ${stateClasses} ${className}`}
+      className={cn(
+        BASE_CLASSES,
+        sizeClasses[size],
+        ROUNDED_CLASSES[rounded],
+        variantClasses[variant],
+        filledThemeClass,
+        widthClass,
+        stateClasses,
+        className,
+      )}
+      {...rest}
     >
       {iconStart && <span className="mr-1">{iconStart}</span>}
       {children}

--- a/packages/ui/src/components/CollapseAndExpandControls.tsx
+++ b/packages/ui/src/components/CollapseAndExpandControls.tsx
@@ -1,20 +1,23 @@
+import type { ComponentPropsWithRef } from "react";
+
 import { ChevronsUpDown, ChevronsDownUp } from "lucide-react";
 
 import { IconButton } from "./IconButton.tsx";
 
-interface SpanCardExpandAllButtonProps {
+export type SpanCardExpandAllButtonProps = ComponentPropsWithRef<"button"> & {
   onExpandAll: () => void;
-}
+};
 
-interface SpanCardCollapseAllButtonProps {
+export type SpanCardCollapseAllButtonProps = ComponentPropsWithRef<"button"> & {
   onCollapseAll: () => void;
-}
+};
 
 export const ExpandAllButton = ({
   onExpandAll,
+  ...rest
 }: SpanCardExpandAllButtonProps) => {
   return (
-    <IconButton onClick={onExpandAll} aria-label="Expand all">
+    <IconButton onClick={onExpandAll} aria-label="Expand all" {...rest}>
       <ChevronsUpDown className="size-3.5" />
     </IconButton>
   );
@@ -22,9 +25,10 @@ export const ExpandAllButton = ({
 
 export const CollapseAllButton = ({
   onCollapseAll,
+  ...rest
 }: SpanCardCollapseAllButtonProps) => {
   return (
-    <IconButton onClick={onCollapseAll} aria-label="Collapse all">
+    <IconButton onClick={onCollapseAll} aria-label="Collapse all" {...rest}>
       <ChevronsDownUp className="size-3.5" />
     </IconButton>
   );

--- a/packages/ui/src/components/CollapsibleSection.tsx
+++ b/packages/ui/src/components/CollapsibleSection.tsx
@@ -1,4 +1,5 @@
 import * as Collapsible from "@radix-ui/react-collapsible";
+import cn from "classnames";
 import { ChevronDown } from "lucide-react";
 import * as React from "react";
 
@@ -49,21 +50,28 @@ export const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
     <Collapsible.Root
       open={open}
       onOpenChange={setOpen}
-      className={`rounded-lg ${className}`}
+      className={cn("rounded-lg", className)}
     >
       <Collapsible.Trigger
-        className={`mb-1 flex w-full items-center gap-2 rounded-lg px-1 py-3 text-left text-sm font-medium text-gray-700 dark:text-white ${triggerClassName}`}
+        className={cn(
+          "mb-1 flex w-full items-center gap-2 rounded-lg px-1 py-3 text-left text-sm font-medium text-gray-700 dark:text-white",
+          triggerClassName,
+        )}
       >
         <ChevronDown
-          className={`h-3 w-3 text-gray-500 transition-transform duration-200 ${
-            open ? "rotate-180" : ""
-          }`}
+          className={cn(
+            "h-3 w-3 text-gray-500 transition-transform duration-200",
+            open && "rotate-180",
+          )}
         />
         <span className="truncate">{title}</span>
       </Collapsible.Trigger>
 
       <Collapsible.Content
-        className={`data-[state=closed]:animate-slideUp data-[state=open]:animate-slideDown ${contentClassName}`}
+        className={cn(
+          "data-[state=closed]:animate-slideUp data-[state=open]:animate-slideDown",
+          contentClassName,
+        )}
       >
         {children}
       </Collapsible.Content>

--- a/packages/ui/src/components/IconButton.tsx
+++ b/packages/ui/src/components/IconButton.tsx
@@ -1,11 +1,11 @@
-import type { ButtonHTMLAttributes } from "react";
+import type { ComponentPropsWithRef } from "react";
 
 import cn from "classnames";
 
 type IconButtonSize = "sm" | "md" | "lg";
 type IconButtonVariant = "default" | "ghost";
 
-interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+export type IconButtonProps = ComponentPropsWithRef<"button"> & {
   /**
    * The size of the icon button
    */
@@ -21,7 +21,7 @@ interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
    * Required for accessibility compliance
    */
   "aria-label": string;
-}
+};
 
 const sizeClasses: Record<IconButtonSize, string> = {
   sm: "h-5 min-h-5",
@@ -42,13 +42,12 @@ export const IconButton = ({
   variant = "default",
   type = "button",
   "aria-label": ariaLabel,
-  ...props
+  ...rest
 }: IconButtonProps) => {
   return (
     <button
       type={type}
       aria-label={ariaLabel}
-      {...props}
       className={cn(
         className,
         sizeClasses[size],
@@ -57,6 +56,7 @@ export const IconButton = ({
         "text-gray-500 dark:text-gray-400",
         "hover:bg-gray-200 dark:hover:bg-gray-800",
       )}
+      {...rest}
     >
       {children}
     </button>

--- a/packages/ui/src/components/PriceBadge.tsx
+++ b/packages/ui/src/components/PriceBadge.tsx
@@ -1,13 +1,15 @@
+import type { ComponentPropsWithRef } from "react";
+
 import { Badge, type BadgeProps } from "./Badge";
 
-interface PriceBadgeProps {
+export type PriceBadgeProps = ComponentPropsWithRef<"span"> & {
   cost: number;
   size?: BadgeProps["size"];
-}
+};
 
-export const PriceBadge = ({ cost, size = "xs" }: PriceBadgeProps) => {
+export const PriceBadge = ({ cost, size = "xs", ...rest }: PriceBadgeProps) => {
   return (
-    <Badge theme="gray" size={size}>
+    <Badge theme="gray" size={size} {...rest}>
       $ {cost}
     </Badge>
   );

--- a/packages/ui/src/components/SpanStatus.tsx
+++ b/packages/ui/src/components/SpanStatus.tsx
@@ -1,14 +1,15 @@
 import type { TraceSpanStatus } from "@ai-agent-trace-ui/types";
+import type { ComponentPropsWithRef } from "react";
 
 import cn from "classnames";
 import { Check, Ellipsis, Info, TriangleAlert } from "lucide-react";
 
 type StatusVariant = "dot" | "badge";
 
-interface StatusProps {
+export type StatusProps = ComponentPropsWithRef<"div"> & {
   status: TraceSpanStatus;
   variant?: StatusVariant;
-}
+};
 
 const STATUS_COLORS_DOT: Record<TraceSpanStatus, string> = {
   success: "bg-green-500 dark:bg-green-500",
@@ -26,11 +27,15 @@ const STATUS_COLORS_BADGE: Record<TraceSpanStatus, string> = {
     "bg-yellow-100 dark:bg-yellow-950 text-yellow-600 dark:text-yellow-400",
 };
 
-export const SpanStatus = ({ status, variant = "dot" }: StatusProps) => {
+export const SpanStatus = ({
+  status,
+  variant = "dot",
+  ...rest
+}: StatusProps) => {
   const title = `Status: ${status}`;
 
   return (
-    <div className="flex size-4 items-center justify-center">
+    <div className="flex size-4 items-center justify-center" {...rest}>
       {variant === "dot" ? (
         <SpanStatusDot status={status} title={title} />
       ) : (

--- a/packages/ui/src/components/Tabs.tsx
+++ b/packages/ui/src/components/Tabs.tsx
@@ -1,3 +1,5 @@
+import type { ComponentPropsWithRef } from "react";
+
 import * as RadixTabs from "@radix-ui/react-tabs";
 import cn from "classnames";
 import * as React from "react";
@@ -26,7 +28,7 @@ const THEMES = {
   },
 } as const;
 
-export interface TabsProps {
+export type TabsProps = Omit<ComponentPropsWithRef<"div">, "dir"> & {
   /**
    * Array of tab items to display
    */
@@ -71,9 +73,14 @@ export interface TabsProps {
    * Optional className for the tab content area
    */
   contentClassName?: string;
-}
 
-export const Tabs: React.FC<TabsProps> = ({
+  /**
+   * The direction of the content of the tabs
+   */
+  dir?: "ltr" | "rtl";
+};
+
+export const Tabs = ({
   items,
   defaultValue,
   value,
@@ -83,8 +90,9 @@ export const Tabs: React.FC<TabsProps> = ({
   tabsListClassName = "",
   triggerClassName = "",
   contentClassName = "",
-  ...props
-}) => {
+  dir,
+  ...rest
+}: TabsProps) => {
   const defaultTab = defaultValue || items[0]?.value;
 
   const currentTheme = THEMES[theme];
@@ -95,7 +103,8 @@ export const Tabs: React.FC<TabsProps> = ({
       defaultValue={!value ? defaultTab : undefined}
       value={value}
       onValueChange={onValueChange}
-      {...props}
+      dir={dir}
+      {...rest}
     >
       <RadixTabs.List
         className={cn(currentTheme.list, tabsListClassName)}

--- a/packages/ui/src/components/Tabs.tsx
+++ b/packages/ui/src/components/Tabs.tsx
@@ -1,4 +1,5 @@
 import * as RadixTabs from "@radix-ui/react-tabs";
+import cn from "classnames";
 import * as React from "react";
 
 export interface TabItem {
@@ -90,14 +91,14 @@ export const Tabs: React.FC<TabsProps> = ({
 
   return (
     <RadixTabs.Root
-      className={`w-full ${className}`}
+      className={cn("w-full", className)}
       defaultValue={!value ? defaultTab : undefined}
       value={value}
       onValueChange={onValueChange}
       {...props}
     >
       <RadixTabs.List
-        className={`${currentTheme.list} ${tabsListClassName}`}
+        className={cn(currentTheme.list, tabsListClassName)}
         aria-label="Navigation tabs"
       >
         {items.map((item: TabItem) => (
@@ -105,10 +106,14 @@ export const Tabs: React.FC<TabsProps> = ({
             key={item.value}
             value={item.value}
             disabled={item.disabled}
-            className={`flex items-center ${currentTheme.trigger} ${triggerClassName}`}
+            className={cn(
+              "flex items-center overflow-hidden",
+              currentTheme.trigger,
+              triggerClassName,
+            )}
           >
             {item.icon && <span className="mr-2">{item.icon}</span>}
-            {item.label}
+            <span className="truncate">{item.label}</span>
           </RadixTabs.Trigger>
         ))}
       </RadixTabs.List>

--- a/packages/ui/src/components/TextInput.tsx
+++ b/packages/ui/src/components/TextInput.tsx
@@ -3,12 +3,12 @@ import { X } from "lucide-react";
 import {
   useRef,
   type ChangeEvent,
-  type InputHTMLAttributes,
+  type ComponentPropsWithRef,
   type ReactNode,
   type RefObject,
 } from "react";
 
-export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
+export type TextInputProps = ComponentPropsWithRef<"input"> & {
   /**
    * Callback fired when the input value changes
    */
@@ -50,7 +50,7 @@ export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
    * @default false
    */
   hideLabel?: boolean;
-}
+};
 
 const iconBaseClassName =
   "absolute top-1/2 -translate-y-1/2 flex items-center justify-center text-gray-700 dark:text-gray-500";
@@ -66,7 +66,7 @@ export const TextInput = ({
   label,
   hideLabel = false,
   id,
-  ...props
+  ...rest
 }: TextInputProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -106,7 +106,6 @@ export const TextInput = ({
         )}
       >
         <input
-          {...props}
           id={id}
           ref={ref || inputRef}
           onChange={handleChange}
@@ -121,13 +120,14 @@ export const TextInput = ({
             "hover:border-gray-300 dark:hover:border-gray-700",
             "outline-none outline-offset-0 focus-visible:outline-1 focus-visible:outline-blue-600 dark:focus-visible:outline-blue-300",
           )}
+          {...rest}
         />
         {startIcon && (
           <div className={cn(iconBaseClassName, "left-2")} aria-hidden>
             {startIcon}
           </div>
         )}
-        {onClear && props.value && (
+        {onClear && rest.value && (
           <button
             className={cn(iconBaseClassName, "right-2")}
             aria-label="Clear input value"

--- a/packages/ui/src/components/TokensBadge.tsx
+++ b/packages/ui/src/components/TokensBadge.tsx
@@ -1,15 +1,26 @@
+import type { ComponentPropsWithRef } from "react";
+
 import { Coins } from "lucide-react";
 
 import { Badge, type BadgeProps } from "./Badge";
 
-interface TokensBadgeProps {
+export type TokensBadgeProps = ComponentPropsWithRef<"span"> & {
   tokensCount: number;
   size?: BadgeProps["size"];
-}
+};
 
-export const TokensBadge = ({ tokensCount, size = "xs" }: TokensBadgeProps) => {
+export const TokensBadge = ({
+  tokensCount,
+  size = "xs",
+  ...rest
+}: TokensBadgeProps) => {
   return (
-    <Badge iconStart={<Coins className="size-2.5" />} theme="gray" size={size}>
+    <Badge
+      iconStart={<Coins className="size-2.5" />}
+      theme="gray"
+      size={size}
+      {...rest}
+    >
       {tokensCount}
     </Badge>
   );

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -16,7 +16,7 @@ export { default as CollapseAndExpandControlsSource } from "./components/Collaps
 export { CollapsibleSection } from "./components/CollapsibleSection";
 export { default as CollapsibleSectionSource } from "./components/CollapsibleSection.tsx?raw";
 
-export { IconButton } from "./components/IconButton";
+export { IconButton, type IconButtonProps } from "./components/IconButton";
 export { default as IconButtonSource } from "./components/IconButton.tsx?raw";
 
 export { PriceBadge } from "./components/PriceBadge";


### PR DESCRIPTION
Relates to #70 

### Changes
- Added gray bg for avatar and error state - now it image fails to load, simple `<User />` icon will be displayed instead
- Updated stories for CollapsibleSection, Tabs and Avatar
- Made Tab truncate its content instead of wrapping to the new line
- Added balck/white bg for stories depending on user theme
- Updated all atoms' types by the pattern `type Props = ComponentPropsWithRef<'tag-name'> & { ... } `